### PR TITLE
solved the bug. convert_y_unit function supports Numpy Array as input…

### DIFF
--- a/DeepPurpose/utils.py
+++ b/DeepPurpose/utils.py
@@ -850,21 +850,26 @@ def generate_config(drug_encoding = None, target_encoding = None,
 	return base_config
 
 def convert_y_unit(y, from_, to_):
+	array_flag = False
+	if isinstance(y, (int, float)):
+		y = np.array([y])
+		array_flag = True
+	y = y.astype(float)    
 	# basis as nM
-
 	if from_ == 'nM':
 		y = y
 	elif from_ == 'p':
 		y = 10**(-y) / 1e-9
 
 	if to_ == 'p':
-		if y == 0:
-			y = -np.log10(10**-10)
-		else:
-			y = -np.log10(y*1e-9)
+		zero_idxs = np.where(y == 0.)[0]
+		y[zero_idxs] = 1e-10
+		y = -np.log10(y*1e-9)
 	elif to_ == 'nM':
 		y = y
-
+        
+	if array_flag:
+		return y[0]
 	return y
 
 def protein2emb_encoder(x):


### PR DESCRIPTION
… (#66)

* solved diving by zero bug

* solved the bug. Now it supports numpy array as input

* Update utils.py

Co-authored-by: Ken Kao <KenKao@Kens-MacBook-Pro.local>
Co-authored-by: Kexin Huang <kexinhuang@hsph.harvard.edu>
Co-authored-by: Kexin Huang <kh2383@nyu.edu>